### PR TITLE
Don't assume it is in a CI context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,24 @@ env:
   matrix:
     
     - CONDA_NPY=110  CONDA_PY=27
-    - CONDA_NPY=19  CONDA_PY=27
+    - CONDA_NPY=111  CONDA_PY=27
     - CONDA_NPY=110  CONDA_PY=34
-    - CONDA_NPY=19  CONDA_PY=34
+    - CONDA_NPY=111  CONDA_PY=34
     - CONDA_NPY=110  CONDA_PY=35
-    - CONDA_NPY=19  CONDA_PY=35
+    - CONDA_NPY=111  CONDA_PY=35
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "M3/KxkR4BYLd87RP+g20G1ZUePvDRuctCvSNMiCqxmQg6NQTnY9yFYMRDB1Jj6WwdRlOK/eu9qwSkiva7zfeXbRpj+MmhQ4pcziS+Hw8hSt3bm2VCVkeD6GPY1ySc5d08SqfD/AIz3jYryc2mbSa0yoAm5rlBhWnPg4HH8Vimt35U2BV5bR3zFoxEPzGWLq1CXeDIGVlgVBG6LdSjerG4rp8om/SdyguXTQbYTgCP746bXkyJFIIoQ0gJFVvScZ88Jz7MYkUPsaGgxulQDRkbheNrv3OlCjue1NRvDwtVSofrICzgR/XaKcOk/G0p2BN8X22V2XLhvIb+u22Q6kLdQg4aHsZGvQQqcH9E7tPXNPZbu+JSwBEHRGnKlzhL5W+7HzK5V70zFPHxIBA54N/NK2bjMZ4Y4ASl5Keq3GkyJE7tzmN5N3kZpYQNZ++M0K1e94rsV12OF4OzPOp95LSA9idxnr1B0b+fT8fbZBYpf/D5OGn+STL2fcE4ouYUAg2N1zS5coF8c5aHWBobnXxmD7yJepJhL1mWPGvmKG9IpR5aRoZF83rL0AKU/szzwIEtmf5e04nso2CXNBDNgjdMjqiL+vxmvyfjzab5tY6HDGZNapCfaDZ+RQ3VSJXc9iULTaVHoXMhd4Kla66ANgbmkiOM6nakrUpxUwCSdxjDbc="
 
 
+before_install:
+    - brew remove --force $(brew list)
+
 install:
     - |
       MINICONDA_URL="http://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      wget "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,10 +25,10 @@ environment:
       CONDA_PY: 27
 
     - TARGET_ARCH: x86
-      CONDA_NPY: 19
+      CONDA_NPY: 111
       CONDA_PY: 27
     - TARGET_ARCH: x64
-      CONDA_NPY: 19
+      CONDA_NPY: 111
       CONDA_PY: 27
 
     - TARGET_ARCH: x86
@@ -39,10 +39,10 @@ environment:
       CONDA_PY: 34
 
     - TARGET_ARCH: x86
-      CONDA_NPY: 19
+      CONDA_NPY: 111
       CONDA_PY: 34
     - TARGET_ARCH: x64
-      CONDA_NPY: 19
+      CONDA_NPY: 111
       CONDA_PY: 34
 
     - TARGET_ARCH: x86
@@ -50,6 +50,13 @@ environment:
       CONDA_PY: 35
     - TARGET_ARCH: x64
       CONDA_NPY: 110
+      CONDA_PY: 35
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 111
+      CONDA_PY: 35
+    - TARGET_ARCH: x64
+      CONDA_NPY: 111
       CONDA_PY: 35
 
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -52,7 +52,7 @@ conda info
     /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_NPY=19
+    export CONDA_NPY=111
     export CONDA_PY=27
     set +x
     conda build /recipe_root --quiet || exit 1
@@ -66,7 +66,7 @@ conda info
     /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_NPY=19
+    export CONDA_NPY=111
     export CONDA_PY=34
     set +x
     conda build /recipe_root --quiet || exit 1
@@ -80,7 +80,7 @@ conda info
     /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_NPY=19
+    export CONDA_NPY=111
     export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-if [ `uname` == Darwin ]; then
-    # Remove gfortran so that all fortran Py-ART modules are not built.  This
-    # avoids the need to package the gfortran run time in the conda package.
-    rm -f /usr/local/bin/gfor*
-fi
+
 export RSL_PATH=$PREFIX
 $PYTHON setup.py install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,14 +10,14 @@ source:
     md5: 6c382dda78193c730a6a47d2d7b18eeb
 
 build:
-    skip: True # [win and py35 and np==19]
+    skip: True  # [win and py35 and np==19]
     number: 0
 
 requirements:
     build:
         - python
         - numpy x.x
-        - trmm_rsl   # [not win]
+        - trmm_rsl  # [not win]
 
     run:
         - python
@@ -33,7 +33,7 @@ test:
 
 about:
     home: http://arm-doe.github.io/pyart/
-    license: BSD
+    license: BSD-3-Clause
     summary: "Python ARM Radar Toolkit"
 
 extra:


### PR DESCRIPTION
`gfortran` is remove in https://github.com/conda-forge/arm_pyart-feedstock/compare/master...ocefpaf:fix_5?expand=1#diff-354f30a63fb0907d4ad57269548329e3R21

PS:  Consider testing this with conda's `gcc`/`libgcc`. I have some success using it for Fortran extensions on both Linux and OS X.
